### PR TITLE
Add variant-based naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/flutter/

--- a/README.md
+++ b/README.md
@@ -14,3 +14,34 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Build Flavors
+
+This project defines three flavors: `dev`, `stg`, and `prod`.
+Each flavor can be built with the debug, release or profile build types.
+Each build variant appends the flavor and build type to the application name and package name. For example `stgRelease` is built as `openai_codex_practice-stgRelease` with the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release`. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
+
+
+### Android
+Run the desired flavor with:
+
+```
+flutter run --flavor <flavor> -t lib/main_<flavor>.dart
+```
+
+### iOS
+Schemes matching each flavor have been added. Use:
+
+```
+flutter run --flavor <flavor> -t lib/main_<flavor>.dart
+```
+
+
+## Testing
+
+Run unit tests with Flutter:
+
+```
+flutter test
+```
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ samples, guidance on mobile development, and a full API reference.
 
 This project defines three flavors: `dev`, `stg`, and `prod`.
 Each flavor can be built with the debug, release or profile build types.
-All build variants share the display name **Codex**. Package names still include the flavor and build type. For example the `stgRelease` variant uses the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release` while keeping the same app name. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
+Every variant appends its flavor and build type to the app name and
+package. For example `stgRelease` builds use the display name
+`Codex-stgRelease` and package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release`.
+`prodRelease` omits the suffix while `prodDebug` and `prodProfile`
+use only the build type as the suffix.
 
 
 ### Android
@@ -35,6 +39,9 @@ Schemes matching each flavor have been added. Use:
 ```
 flutter run --flavor <flavor> -t lib/main_<flavor>.dart
 ```
+
+Set `APP_SUFFIX` in your Xcode scheme so the iOS app name matches the
+Android variant (e.g. `-stgRelease`).
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ samples, guidance on mobile development, and a full API reference.
 
 This project defines three flavors: `dev`, `stg`, and `prod`.
 Each flavor can be built with the debug, release or profile build types.
-Each build variant appends the flavor and build type to the application and package names. The resource files under `android/app/src/*/res` provide the display name for each variant. For example `stgRelease` is built as `openai_codex_practice-stgRelease` with the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release`. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
+All build variants share the display name **Codex**. Package names still include the flavor and build type. For example the `stgRelease` variant uses the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release` while keeping the same app name. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
 
 
 ### Android

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ samples, guidance on mobile development, and a full API reference.
 
 This project defines three flavors: `dev`, `stg`, and `prod`.
 Each flavor can be built with the debug, release or profile build types.
-Each build variant appends the flavor and build type to the application name and package name. For example `stgRelease` is built as `openai_codex_practice-stgRelease` with the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release`. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
+Each build variant appends the flavor and build type to the application and package names. The resource files under `android/app/src/*/res` provide the display name for each variant. For example `stgRelease` is built as `openai_codex_practice-stgRelease` with the package `dylan.kwon.flutter.codex.openai_codex_practice.stg.release`. The `prod` flavor omits the suffix for release builds and only adds the build type for other variants.
 
 
 ### Android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,20 +58,6 @@ android {
             applicationIdSuffix ".profile"
         }
     }
-    applicationVariants.all { variant ->
-        def flavor = variant.flavorName
-        def buildType = variant.buildType.name
-        def buildTypeCap = buildType.capitalize()
-        def appSuffix = ""
-        if (flavor == "prod" && buildType == "release") {
-            appSuffix = ""
-        } else if (flavor == "prod") {
-            appSuffix = "-" + buildTypeCap
-        } else {
-            appSuffix = "-" + flavor + buildTypeCap
-        }
-        variant.resValue "string", "app_name", "openai_codex_practice" + appSuffix
-    }
 }
 
 flutter {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,12 +30,48 @@ android {
         versionName = flutter.versionName
     }
 
+    flavorDimensions += "env"
+    productFlavors {
+        dev {
+            dimension "env"
+        }
+        stg {
+            dimension "env"
+        }
+        prod {
+            dimension "env"
+        }
+    }
+
     buildTypes {
+        debug {
+        }
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
         }
+        profile {
+        }
+    }
+    applicationVariants.all { variant ->
+        def flavor = variant.flavorName
+        def buildType = variant.buildType.name
+        def buildTypeCap = buildType.capitalize()
+        def appSuffix = ""
+        def idSuffix = ""
+        if (flavor == "prod" && buildType == "release") {
+            appSuffix = ""
+            idSuffix = ""
+        } else if (flavor == "prod") {
+            appSuffix = "-" + buildTypeCap
+            idSuffix = "." + buildType
+        } else {
+            appSuffix = "-" + flavor + buildTypeCap
+            idSuffix = "." + flavor + "." + buildType
+        }
+        variant.resValue "string", "app_name", "openai_codex_practice" + appSuffix
+        variant.mergedFlavor.applicationIdSuffix = idSuffix
     }
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,9 +34,11 @@ android {
     productFlavors {
         dev {
             dimension "env"
+            applicationIdSuffix ".dev"
         }
         stg {
             dimension "env"
+            applicationIdSuffix ".stg"
         }
         prod {
             dimension "env"
@@ -45,6 +47,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix ".debug"
         }
         release {
             // TODO: Add your own signing config for the release build.
@@ -52,6 +55,7 @@ android {
             signingConfig = signingConfigs.debug
         }
         profile {
+            applicationIdSuffix ".profile"
         }
     }
     applicationVariants.all { variant ->
@@ -59,19 +63,14 @@ android {
         def buildType = variant.buildType.name
         def buildTypeCap = buildType.capitalize()
         def appSuffix = ""
-        def idSuffix = ""
         if (flavor == "prod" && buildType == "release") {
             appSuffix = ""
-            idSuffix = ""
         } else if (flavor == "prod") {
             appSuffix = "-" + buildTypeCap
-            idSuffix = "." + buildType
         } else {
             appSuffix = "-" + flavor + buildTypeCap
-            idSuffix = "." + flavor + "." + buildType
         }
         variant.resValue "string", "app_name", "openai_codex_practice" + appSuffix
-        variant.mergedFlavor.applicationIdSuffix = idSuffix
     }
 }
 

--- a/android/app/src/devDebug/res/values/strings.xml
+++ b/android/app/src/devDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-devDebug</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/devDebug/res/values/strings.xml
+++ b/android/app/src/devDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-devDebug</string>
 </resources>

--- a/android/app/src/devDebug/res/values/strings.xml
+++ b/android/app/src/devDebug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-devDebug</string>
+</resources>

--- a/android/app/src/devProfile/res/values/strings.xml
+++ b/android/app/src/devProfile/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-devProfile</string>
+</resources>

--- a/android/app/src/devProfile/res/values/strings.xml
+++ b/android/app/src/devProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-devProfile</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/devProfile/res/values/strings.xml
+++ b/android/app/src/devProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-devProfile</string>
 </resources>

--- a/android/app/src/devRelease/res/values/strings.xml
+++ b/android/app/src/devRelease/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-devRelease</string>
+</resources>

--- a/android/app/src/devRelease/res/values/strings.xml
+++ b/android/app/src/devRelease/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-devRelease</string>
 </resources>

--- a/android/app/src/devRelease/res/values/strings.xml
+++ b/android/app/src/devRelease/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-devRelease</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="openai_codex_practice"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice</string>
+</resources>

--- a/android/app/src/prodDebug/res/values/strings.xml
+++ b/android/app/src/prodDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-Debug</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/prodDebug/res/values/strings.xml
+++ b/android/app/src/prodDebug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-Debug</string>
+</resources>

--- a/android/app/src/prodDebug/res/values/strings.xml
+++ b/android/app/src/prodDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-Debug</string>
 </resources>

--- a/android/app/src/prodProfile/res/values/strings.xml
+++ b/android/app/src/prodProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-Profile</string>
 </resources>

--- a/android/app/src/prodProfile/res/values/strings.xml
+++ b/android/app/src/prodProfile/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-Profile</string>
+</resources>

--- a/android/app/src/prodProfile/res/values/strings.xml
+++ b/android/app/src/prodProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-Profile</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/prodRelease/res/values/strings.xml
+++ b/android/app/src/prodRelease/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/prodRelease/res/values/strings.xml
+++ b/android/app/src/prodRelease/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice</string>
+</resources>

--- a/android/app/src/stgDebug/res/values/strings.xml
+++ b/android/app/src/stgDebug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-stgDebug</string>
+</resources>

--- a/android/app/src/stgDebug/res/values/strings.xml
+++ b/android/app/src/stgDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-stgDebug</string>
 </resources>

--- a/android/app/src/stgDebug/res/values/strings.xml
+++ b/android/app/src/stgDebug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-stgDebug</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/stgProfile/res/values/strings.xml
+++ b/android/app/src/stgProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-stgProfile</string>
 </resources>

--- a/android/app/src/stgProfile/res/values/strings.xml
+++ b/android/app/src/stgProfile/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-stgProfile</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/stgProfile/res/values/strings.xml
+++ b/android/app/src/stgProfile/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-stgProfile</string>
+</resources>

--- a/android/app/src/stgRelease/res/values/strings.xml
+++ b/android/app/src/stgRelease/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">openai_codex_practice-stgRelease</string>
+    <string name="app_name">Codex</string>
 </resources>

--- a/android/app/src/stgRelease/res/values/strings.xml
+++ b/android/app/src/stgRelease/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">openai_codex_practice-stgRelease</string>
+</resources>

--- a/android/app/src/stgRelease/res/values/strings.xml
+++ b/android/app/src/stgRelease/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Codex</string>
+    <string name="app_name">Codex-stgRelease</string>
 </resources>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/prod.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/stg.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/stg.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-        <string>Codex</string>
+        <key>CFBundleDisplayName</key>
+        <string>Codex$(APP_SUFFIX)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Openai Codex Practice</string>
+        <string>Codex</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,5 @@
+import 'main.dart' as entry;
+
+void main() {
+  entry.main();
+}

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,0 +1,5 @@
+import 'main.dart' as entry;
+
+void main() {
+  entry.main();
+}

--- a/lib/main_stg.dart
+++ b/lib/main_stg.dart
@@ -1,0 +1,5 @@
+import 'main.dart' as entry;
+
+void main() {
+  entry.main();
+}


### PR DESCRIPTION
## Summary
- ignore local Flutter SDK
- add simple entrypoints for dev/stg/prod flavors
- define dev, stg and prod flavors in Android build.gradle
- copy Runner scheme for each flavor on iOS
- document how to run flavors
- document how to run tests with `flutter test`
- add suffix-based naming for each Android variant

## Testing
- `flutter/bin/flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68495107f9e083249ab4b2adc2fce053